### PR TITLE
Add prototype GitLab-CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,46 @@
+stages:
+  - test
+  - posttest
+
+#
+# Test-job template
+#
+
+.ensembl_test_template:
+  image: dockerhub.ebi.ac.uk/ensembl-infrastructure/ensembl-ci-docker-images:${PERL_VERSION}
+
+  variables:
+    USER: "gitlabci"
+
+  before_script:
+    - apt-get update
+    - apt-get install -y build-essential cpanminus git
+    - git clone --branch=master --depth=1 https://github.com/Ensembl/ensembl.git
+    - git clone --branch=release-1-6-924 --depth=1 https://github.com/bioperl/bioperl-live.git
+    - cpanm -v --installdeps --notest .
+    - cpanm -n Devel::Cover::Report::Coveralls
+    - perl Makefile.PL
+    - make
+
+#
+# Test jobs
+#
+
+test:perl5.14:
+  stage: test
+  extends: .ensembl_test_template
+  variables:
+    PERL_VERSION: "5.14"
+    COVERALLS: "false"
+  script:
+    - ./travisci/harness.sh
+
+test:perl5.30:
+  stage: test
+  extends: .ensembl_test_template
+  variables:
+    PERL_VERSION: "5.30"
+    # Note: relies on the secret variable COVERALLS_REPO_TOKEN for report uploads to work
+    COVERALLS: "true"
+  script:
+    - ./travisci/harness.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,3 @@
-stages:
-  - test
-  - posttest
-
 #
 # Test-job template
 #


### PR DESCRIPTION
A fairly minimal set-up, with three changes of note with respect to Travis configuration: dropped perl-5.10 builds, switched from perl-5.26 to perl-5.30, and use the master branch of _ensembl_ rather than the long-obsolete experimental/mapper_update. Moreover, unlike Travis we do
measure test coverage - for 5.30 tests.
