### PR TITLE
Git clone the master branch of the ensembl repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
     - unzip
 
 before_install:
-  - git clone --branch experimental/mapper_update --depth 1 https://github.com/Ensembl/ensembl.git
+  - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl.git
   - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 install:


### PR DESCRIPTION
The Travis build is currently failing due to line 22 in the `.travis.yml` file:
`git clone --branch experimental/mapper_update --depth 1 https://github.com/Ensembl/ensembl.git`

This line has been updated to use the master branch of the ensembl repo.