### PR TITLE
Copyright optimisation

### DIFF
--- a/Bio-EnsEMBL.xs
+++ b/Bio-EnsEMBL.xs
@@ -1,6 +1,6 @@
 /*
-  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-  Copyright [2016-2024] EMBL-European Bioinformatics Institute
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership.
   
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/INSTALL
+++ b/INSTALL
@@ -3,9 +3,6 @@
 
 			     Version 2.3.2
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute     
-
 
 OBTAINING THE ENSEMBL API EXTENSIONS
 ------------------------------------
@@ -103,21 +100,3 @@ AUTHOR
 The module and the extensions have been written by Alessandro Vullo <avullo@ebi.ac.uk>
 with the assistance of Andy Yates and contribution of Will McLaren.
 
-
-LICENSE AND COPYRIGHT
----------------------
-
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute     
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
-                                Apache License
+
+                                 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
 
@@ -178,7 +179,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [1999-2013] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,3 +200,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-  Copyright [2016-2024] EMBL-European Bioinformatics Institute
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+Ensembl
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2024] EMBL-European Bioinformatics Institute
+
+This product includes software developed at:
+- EMBL-European Bioinformatics Institute
+- Wellcome Trust Sanger Institute

--- a/README
+++ b/README
@@ -8,9 +8,6 @@ the rewrite in order to make sure your local commit history is clean.
 
 			     Version 2.3.2
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute     
-
 
 The Bio::EnsEMBL::XS module uses the Perl XS layer to provide fast re-implementations 
 in C of some procedures of the Ensembl API, written in pure perl. 
@@ -45,21 +42,3 @@ AUTHOR
 The module and the extensions have been written by Alessandro Vullo <avullo@ebi.ac.uk>
 with the assistance of Andy Yates and contribution of Will McLaren.
 
-
-LICENSE AND COPYRIGHT
----------------------
-
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute     
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
- 
-     http://www.apache.org/licenses/LICENSE-2.0
- 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.

--- a/bin/assert_numeric-bench.pl
+++ b/bin/assert_numeric-bench.pl
@@ -1,6 +1,6 @@
 #!perl 
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bin/assert_ref-bench.pl
+++ b/bin/assert_ref-bench.pl
@@ -1,6 +1,6 @@
 #!perl 
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bin/check_ref-bench.pl
+++ b/bin/check_ref-bench.pl
@@ -1,6 +1,6 @@
 #!perl 
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bin/overlap-bench.pl
+++ b/bin/overlap-bench.pl
@@ -1,6 +1,6 @@
 #!perl 
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bin/rearrange-bench.pl
+++ b/bin/rearrange-bench.pl
@@ -1,6 +1,6 @@
 #!perl 
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/itree/Makefile.PL
+++ b/itree/Makefile.PL
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-  Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-  Copyright [2016-2024] EMBL-European Bioinformatics Institute
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/itree/interval.c
+++ b/itree/interval.c
@@ -1,8 +1,8 @@
 /*
  * Libitree: an interval tree library in C 
  *
- * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- * Copyright [2016-2024] EMBL-European Bioinformatics Institute
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/itree/interval.h
+++ b/itree/interval.h
@@ -1,8 +1,8 @@
 /*
  * Libitree: an interval tree library in C
  *
- * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- * Copyright [2016-2024] EMBL-European Bioinformatics Institute
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/itree/interval_list.c
+++ b/itree/interval_list.c
@@ -1,8 +1,8 @@
 /*
  * Libitree: an interval tree library in C
  *
- * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- * Copyright [2016-2024] EMBL-European Bioinformatics Institute
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/itree/interval_list.h
+++ b/itree/interval_list.h
@@ -1,8 +1,8 @@
 /*
  * Libitree: an interval tree library in C
  *
- * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- * Copyright [2016-2024] EMBL-European Bioinformatics Institute
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/itree/interval_tree.c
+++ b/itree/interval_tree.c
@@ -1,8 +1,8 @@
 /*
  * Libitree: an interval tree library in C
  *
- * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- * Copyright [2016-2024] EMBL-European Bioinformatics Institute
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/itree/interval_tree.h
+++ b/itree/interval_tree.h
@@ -1,8 +1,8 @@
 /*
  * Libitree: an interval tree library in C
  *
- * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- * Copyright [2016-2024] EMBL-European Bioinformatics Institute
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/itree/utils.h
+++ b/itree/utils.h
@@ -1,8 +1,8 @@
 /*
  * Libitree: an interval tree library in C
  *
- * Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
- * Copyright [2016-2024] EMBL-European Bioinformatics Institute
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/Bio/EnsEMBL/XS.pm
+++ b/lib/Bio/EnsEMBL/XS.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/EnsEMBL/XS/Utils/Tree/Interval/Mutable.pm
+++ b/lib/Bio/EnsEMBL/XS/Utils/Tree/Interval/Mutable.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/Bio/EnsEMBL/XS/Utils/Tree/Interval/Mutable/Interval.pm
+++ b/lib/Bio/EnsEMBL/XS/Utils/Tree/Interval/Mutable/Interval.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
-Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2024] EMBL-European Bioinformatics Institute
+See the NOTICE file distributed with this work for additional information
+regarding copyright ownership.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/01-leak.t
+++ b/t/01-leak.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/02-rearrange.t
+++ b/t/02-rearrange.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/03-check_ref.t
+++ b/t/03-check_ref.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/04-assert_ref.t
+++ b/t/04-assert_ref.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/05-assert_numeric.t
+++ b/t/05-assert_numeric.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/06-assert_integer.t
+++ b/t/06-assert_integer.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/07-overlap.t
+++ b/t/07-overlap.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/08-interval-tree.t
+++ b/t/08-interval-tree.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/09-housekeeping_apache2.t
+++ b/t/09-housekeeping_apache2.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/boilerplate.t
+++ b/t/boilerplate.t
@@ -1,6 +1,6 @@
 #!perl -T
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -1,6 +1,6 @@
 #!perl -T
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/pod-coverage.t
+++ b/t/pod-coverage.t
@@ -1,5 +1,5 @@
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,6 +1,6 @@
 #!perl -T
-# Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2024] EMBL-European Bioinformatics Institute
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Centralising the copyright string with the year into the NOTICE file, and fixing the existing LICENSE file, to avoid massive update of the year across the repo.

## Use case

Every year the copyright must be updated. Because the copyright info - for historical reason - is contained in many files, the procedure is risky and annoying.
By centralising the year bit into a single NOTICE file, the entire updating procedure becomes trivial.

## Benefits

Centralising the copyright string with the year into the NOTICE file, and fixing the existing LICENSE file, to avoid massive update of the year across the repo.
The copyright update will be easier to do and check.

## Possible Drawbacks

None

## Testing

All good